### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  ignore:
+    # This package has unlisted versions on nuget.org that are not supported. Avoid them.
+    - dependency-name: dotnet-format
+      versions: ["6.x", "7.x", "8.x"]
 - package-ecosystem: cargo
   directory: /src/nerdbank-zcash-rust
   schedule:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,8 +16,8 @@
     <PackageVersion Include="NBitcoin.Secp256k1" Version="3.1.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="xunit.combinatorial" Version="1.6.12-alpha" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,8 +16,8 @@
     <PackageVersion Include="NBitcoin.Secp256k1" Version="3.1.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="xunit.combinatorial" Version="1.6.12-alpha" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -17,7 +17,7 @@ jobs:
     clean: true
   - template: install-dependencies.yml
 
-  - script: dotnet tool run nbgv cloud -c
+  - script: dotnet nbgv cloud -c
     displayName: ⚙ Set build number
 
   - template: dotnet.yml


### PR DESCRIPTION
- Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0 (#210)
- Bump xunit from 2.4.2 to 2.5.0 (#209)
- Remove `tool run` from `dotnet nbgv` invocation
- Dependabot to ignore dotnet-format
